### PR TITLE
feat: 게시글 좋아요, 취소 기능

### DIFF
--- a/src/main/java/com/project/toy/board/controller/BoradController.java
+++ b/src/main/java/com/project/toy/board/controller/BoradController.java
@@ -142,6 +142,7 @@ public class BoradController {
 			likesDTO.setUserId(user.getUserId());
 			
 			int comment = commentService.countComment(id);
+			int likesAll = likesService.selectLikes(likesDTO);
 			
 			if(comment != 0) {
 				model.addAttribute("comment", comment);
@@ -149,10 +150,16 @@ public class BoradController {
 				model.addAttribute("comment", "0");
 			}
 			
-			if(likesService.findLikes(likesDTO) == 0) {
-				model.addAttribute("likes");
+			if(likesAll != 0) {
+				model.addAttribute("likesAll", likesAll);
 			} else {
-				model.addAttribute("likes");
+				model.addAttribute("likesAll", likesAll);
+			}
+			
+			if(likesService.findLikes(likesDTO) == 0) {
+				model.addAttribute("likes", 0);
+			} else {
+				model.addAttribute("likes", 1);
 			}
 		} else {
 			MessageDTO message = new MessageDTO("존재하지 않거나 이미 삭제된 게시글입니다.", "/board", RequestMethod.POST, null);

--- a/src/main/java/com/project/toy/likes/controller/LikesController.java
+++ b/src/main/java/com/project/toy/likes/controller/LikesController.java
@@ -1,0 +1,47 @@
+package com.project.toy.likes.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.google.gson.JsonObject;
+import com.project.toy.likes.dto.LikesDTO;
+import com.project.toy.likes.service.LikesService;
+
+@RestController
+public class LikesController {
+
+	@Autowired
+	private LikesService likesService;
+	
+	/**
+	 * 게시글 좋아요, 취소
+	 * @param boardId
+	 * @param params
+	 * @return
+	 */
+	@PostMapping({"/board/likes", "/board/likes/{boardId}"})
+	public JsonObject saveLikes(@PathVariable(value = "boardId", required = false) Long boardId, @RequestBody final LikesDTO params) {
+		JsonObject jsonObj = new JsonObject();
+		
+		try {
+			int todayLikes = likesService.selectTodayLikes(params);
+			if(todayLikes >= 5) {
+				jsonObj.addProperty("todayLikes", todayLikes);
+				jsonObj.addProperty("message", "좋아요는 하루 5개의 게시글만 가능합니다.");
+			} else {
+				boolean save = likesService.saveOrDeleteLikes(params);
+				jsonObj.addProperty("result", save);				
+			}
+		} catch(DataAccessException e) {
+			jsonObj.addProperty("message", "데이터베이스 처리 과정에 문제가 발생하였습니다.");
+		} catch(Exception e) {
+			jsonObj.addProperty("message", "시스템에 문제가 발생하였습니다.");
+		}
+		
+		return jsonObj;
+	}
+}

--- a/src/main/java/com/project/toy/likes/mapper/LikesMapper.java
+++ b/src/main/java/com/project/toy/likes/mapper/LikesMapper.java
@@ -7,6 +7,9 @@ import com.project.toy.likes.dto.LikesDTO;
 @Mapper
 public interface LikesMapper {
 
+	public int selectLikes(LikesDTO params);
 	public int findLikes(LikesDTO params);
-
+	public int saveLikes(LikesDTO params);
+	public int deleteLikes(LikesDTO params);
+	public int selectTodayLikes(LikesDTO params);
 }

--- a/src/main/java/com/project/toy/likes/service/LikesService.java
+++ b/src/main/java/com/project/toy/likes/service/LikesService.java
@@ -2,6 +2,7 @@ package com.project.toy.likes.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.project.toy.likes.dto.LikesDTO;
 import com.project.toy.likes.mapper.LikesMapper;
@@ -11,6 +12,10 @@ public class LikesService {
 	
 	@Autowired
 	private LikesMapper likesMapper;
+	
+	public int selectLikes(LikesDTO params) {
+		return likesMapper.selectLikes(params);
+	}
 
 	public int findLikes(LikesDTO params) {
 		int findLikes = likesMapper.findLikes(params);
@@ -20,5 +25,28 @@ public class LikesService {
 		} else {
 			return 1;
 		}
+	}
+	
+	@Transactional
+	public boolean saveOrDeleteLikes(LikesDTO params) {
+		int queryResult = 0;
+
+		if (params.getBoardId() != null) {
+			int likes = likesMapper.findLikes(params);
+			
+			params.setBoardId(params.getBoardId());
+			
+			if(likes != 0) {
+				queryResult = likesMapper.deleteLikes(params);
+			} else {
+				queryResult = likesMapper.saveLikes(params);
+			}
+		}
+
+		return (queryResult >= 1) ? true : false;
+	}
+	
+	public int selectTodayLikes(LikesDTO params) {
+		return likesMapper.selectTodayLikes(params);
 	}
 }

--- a/src/main/resources/mybatis/mappers/likes-mapper.xml
+++ b/src/main/resources/mybatis/mappers/likes-mapper.xml
@@ -3,10 +3,50 @@
 
 <mapper namespace="com.project.toy.likes.mapper.LikesMapper">
 
+	<sql id="likesColumns">
+		ID,
+		BOARD_ID,
+		USER_ID,
+		I_DATE
+	</sql>
+	
+	<select id="selectLikes" parameterType="LikesDTO" resultType="int">
+		SELECT COUNT(1) FROM BOARD_LIKES WHERE BOARD_ID = #{ boardId } AND USE_YN = 'Y'
+	</select>
+	
+	<!-- 좋아요한 게시글 카운트 -->
 	<select id="findLikes" resultType="int">
 		/* com.project.toy.likes.dto.LikesDTO */
 		
-		SELECT COUNT(1) FROM BOARD_LIKES WHERE BOARD_ID = #{ boardId } AND USER_ID = #{ userId }
+		SELECT COUNT(1) FROM BOARD_LIKES WHERE BOARD_ID = #{ boardId } AND USER_ID = #{ userId } AND USE_YN = 'Y'
+	</select>
+	
+	<!-- 좋아요 -->
+	<insert id="saveLikes" parameterType="LikesDTO">
+		/* com.project.toy.likes.dto.LikesDTO */
+		
+		INSERT INTO toy.BOARD_LIKES ( <include refid="likesColumns" /> )
+		VALUES ( nextval(BOARD_LIKES_SEQ), #{ boardId }, #{ userId }, NOW() )
+	</insert>
+	
+	<!-- 취소 -->
+	<update id="deleteLikes" parameterType="LikesDTO">
+		/* com.project.toy.likes.dto.LikesDTO */
+		
+		UPDATE toy.BOARD_LIKES
+		SET    USE_YN = 'N'
+		WHERE  1=1
+		AND    BOARD_ID = #{ boardId }
+		AND    USER_ID = #{ userId }
+	</update>
+	
+	<!-- 오늘 좋아요 누른 횟수 -->
+	<select id="selectTodayLikes" parameterType="LikesDTO" resultType="int">
+		SELECT COUNT(1)
+		FROM   BOARD_LIKES
+		WHERE  USER_ID = #{ userId }
+		AND    I_DATE BETWEEN (SELECT DATE_FORMAT(NOW(), '%Y-%m-%d') FROM DUAL) AND NOW()
+		AND    USE_YN = 'Y'
 	</select>
 	
 </mapper>

--- a/src/main/resources/static/css/app/board.css
+++ b/src/main/resources/static/css/app/board.css
@@ -98,6 +98,7 @@ h4 + .search_box { margin-top: 10px; }
 
 /* 좋아요, 수정, 삭제, 뒤로 */
 .board-likes { border: none; background-color: initial; font-size: 20px; justify-content: right; }
+.board-likes span { margin-left: 5px; font-size: 15px; }
 .board-likes img { width: 20px; height: 20px; }
 .board-btn { text-align: right; margin-bottom: 10px; overflow: hidden; }
 

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -74,7 +74,10 @@
 	            </p>
 	            <div class="board-title">
 		            <span class="board-title1">[[ ${board.title} ]]</span>
-		            <button id="board-likes" class="btns btn_mid board-likes"><img src="/img/app/board/unlikes.png"></button>
+		            <button id="board-likes" class="btns btn_mid board-likes">
+		            	<img th:src="${likes != 0 ? '/img/app/board/likes.png' : '/img/app/board/unlikes.png'}" th:onclick="insertLikes([[ ${board.id} ]]);" class="board-likes">
+		            	<span>[[ ${likesAll} ]]</span>
+		            </button>
 	            </div>
 	            <div class="board-info">
 		            <span><span class="board-writer">글쓴이</span>[[ ${board.writer} ]]</span>
@@ -215,7 +218,6 @@
 					success: function(response) {
 						if(response.result == false) {
 							alert("댓글 등록에 실패하였습니다.");
-							console.log(response.count);
 							return false;
 						}
 						
@@ -312,7 +314,6 @@
 				$.get(uri, function(response) {
 					if (isEmpty(response) == false) {
 						var commentsHtml = "";
-						console.log(response);
 
 						$(response.commentList).each(function(id, comment) {
 							commentsHtml += `
@@ -331,6 +332,38 @@
 					}
 				}, "json");
 			}
+			
+			// 게시글 좋아요, 취소
+			function insertLikes(boardId) {
+
+				var uri = [[ @{/board/likes} ]];
+				var headers = { "Content-Type": "application/json", "X-HTTP-Method-Override": "POST" };
+				var params = { "boardId": boardId, "userId": [[ ${userId} ]] };
+				
+				$.ajax({
+					url: uri,
+					type: "POST",
+					headers: headers,
+					dataType: "json",
+					data: JSON.stringify(params),
+					success: function(response) {
+						if(response.todayLikes >= 5) {
+							alert(response.message);
+							return false;
+						} else if(response.result == false) {
+							alert("게시글 좋아요에 실패하였습니다.");
+							return false;
+						} else {
+							window.location.reload(true);						
+						}
+					},
+					error: function(xhr, status, error) {
+						alert("잠시후 재시도 해주세요.");
+						return false;
+					}
+				});
+			}
+			
 		/*]]>*/
 		</script>
 	</th:block>


### PR DESCRIPTION
- 게시글 상세페이지 내 좋아요, 취소 기능 활용
- 빈 하트 상태일 때 버튼을 클릭하면 좋아요(해당 게시글 좋아요 카운트해서 옆에 숫자 표시)
- 채워진 하트 상태일 때 버튼을 클릭하면 좋아요 취소
- 좋아요는 하루 5개의 게시글만 가능(5번 이전까진 언제든지 좋아요, 취소가 가능하지만 그 이후에는 취소가 불가)